### PR TITLE
Alteração do CURLOPT_SSLVERSION

### DIFF
--- a/src/CpfGratis.php
+++ b/src/CpfGratis.php
@@ -22,7 +22,7 @@ class CpfGratis {
 
         $client->getClient()->setDefaultOption('config/curl/'.CURLOPT_SSL_VERIFYPEER, false);
         $client->getClient()->setDefaultOption('config/curl/'.CURLOPT_SSL_VERIFYHOST, false);
-        $client->getClient()->setDefaultOption('config/curl/'.CURLOPT_SSLVERSION, 3);
+        $client->getClient()->setDefaultOption('config/curl/'.CURLOPT_SSLVERSION, 4);
 
         $client->request('GET', 'https://www.receita.fazenda.gov.br/Aplicacoes/SSL/ATCTA/CPF/ConsultaPublica.asp');
 
@@ -61,7 +61,7 @@ class CpfGratis {
 
         $client->getClient()->setDefaultOption('config/curl/'.CURLOPT_SSL_VERIFYPEER, false);
         $client->getClient()->setDefaultOption('config/curl/'.CURLOPT_SSL_VERIFYHOST, false);
-        $client->getClient()->setDefaultOption('config/curl/'.CURLOPT_SSLVERSION, 3);
+        $client->getClient()->setDefaultOption('config/curl/'.CURLOPT_SSLVERSION, 4);
 
         $client->setHeader('Host', 'www.receita.fazenda.gov.br');
         $client->setHeader('User-Agent', 'Mozilla/5.0 (Windows NT 6.1; rv:32.0) Gecko/20100101 Firefox/32.0');


### PR DESCRIPTION
Devido às diversas falhas na segurança do SSLv3, o Ubuntu 16.04 vem com esse protocolo desabilitado por padrão, gerando o seguinte erro: 'cURL error 27: SSL: couldn't create a context: error:140A90C4:SSL routines:SSL_CTX_new:null ssl method passed'.
Entretanto, é possível usar o protocolo TLSv1_0 que já vem por padrão e, dependendo da versão do OpenSSL, é possível usar o TLSv1_1 e TLSv1_2.

Foi testado no Windows com PHP 5.6.19 e funcionou perfeitamente.