### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "fabpot/goutte": "2.0.*@dev",
+        "fabpot/goutte": "3.0",
         "jansenfelipe/utils": "^2.0@dev"
     },
     "autoload": {


### PR DESCRIPTION
Aceitando a sugestão de um colega, atualizar o fabpot/goutte 3.0 pode liberar a instalação em Laravel versão 5.2 ou superior. Veja a issue #24 

Obrigado!